### PR TITLE
ENH: use env variables for docker-compose

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+PYCORTEX_STORE=./
+EVENT_DEVICE=/dev/input/event3
+PIPELINE_PATH=./realtimefmri/pipelines
+TEST_DATASET_PATH=./

--- a/Dockerfile.realtimefmri
+++ b/Dockerfile.realtimefmri
@@ -17,8 +17,7 @@ RUN python3 -m pip install --upgrade pip
 # pycortex
 RUN pip3 install pycortex
 RUN python3 -c "import cortex"
-COPY data/pycortex-options.cfg /root/.config/pycortex/options.cfg
-COPY data/pycortex_store /data/pycortex_store
+COPY config/pycortex-options.cfg /root/.config/pycortex/options.cfg
 
 # realtimefmri
 RUN mkdir -p /code/realtimefmri/realtimefmri
@@ -31,8 +30,6 @@ RUN pip3 install -r requirements.txt
 RUN pip3 install .
 # RUN pip3 install git+https://github.com/gallantlab/realtimefmri.git
 RUN python3 -c "import realtimefmri"
-COPY data/test_dataset /root/.local/share/realtimefmri/datasets/test_dataset
-COPY realtimefmri/pipelines /root/.local/share/realtimefmri/pipelines
 
 WORKDIR /
 ENV PATH="$HOME/abin:$PATH"

--- a/config/pycortex-options.cfg
+++ b/config/pycortex-options.cfg
@@ -1,0 +1,133 @@
+[basic]
+default_cmap = RdBu_r
+default_cmap2D = RdBu_covar
+fsl_prefix = fsl5.0-
+filestore = /data/pycortex_store
+
+[dependency_paths]
+# The following specify paths to the binary executable files
+# for blender and inkscape (which are external dependencies of
+# pycortex). "inkscape" and "blender" alone should work on Linux,
+# since the binaries should already be on the system path.
+# For MacOS, unless you have done some manual configuration on
+# your own, these will need to be something like:
+# blender = /Applications/Blender/blender.app/Contents/MacOS/blender
+# inkscape = /Applications/Inkscape.app/Contents/MacOS/Inkscape
+# Windows is not currently supported.  
+inkscape = inkscape
+blender = blender
+
+[mayavi_aligner]
+line_width = 1
+point_size = 2
+outline_color = white
+outline_rep = wireframe
+opacity = 0
+colormap = gray
+
+[paths_default]
+stroke = white
+fill = none
+display = inline
+filter = url(#dropshadow)
+stroke-width = 3
+stroke-opacity = 1
+fill-opacity = 0
+stroke-dashoffset = None
+stroke-dasharray = None
+
+[labels_default]
+font-family = Helvetica, sans-serif
+font-size = 18pt
+font-weight = bold
+font-style = italic
+fill = white
+fill-opacity = 1
+text-anchor = middle
+filter = url(#dropshadow)
+
+[overlay_paths]
+stroke = white
+fill = none
+display = inline
+filter = url(#dropshadow)
+stroke-width = 2
+stroke-opacity = 1
+fill-opacity = 0
+stroke-dashoffset = None
+stroke-dasharray = None
+
+[overlay_text]
+font-family = Helvetica, sans-serif
+font-size = 14pt
+font-weight = bold
+font-style = italic
+fill = white
+fill-opacity = 1
+text-anchor = middle
+filter = url(#dropshadow)
+
+[rois_paths]
+stroke = white
+fill = none
+display = inline
+filter = url(#dropshadow)
+stroke-width = 2
+stroke-opacity = 1
+fill-opacity = 0
+stroke-dashoffset = None
+stroke-dasharray = None
+
+[rois_labels]
+font-family = Helvetica, sans-serif
+font-size = 14pt
+font-weight = bold
+font-style = italic
+fill = white
+fill-opacity = 1
+text-anchor = middle
+filter = url(#dropshadow)
+
+[sulci_paths]
+stroke = white
+fill = none
+display = inline
+filter = url(#dropshadow)
+stroke-width = 6
+stroke-opacity = 0.6
+fill-opacity = 0
+stroke-dashoffset = None
+stroke-dasharray = None
+stroke-linecap = round
+
+[sulci_labels]
+font-family = Helvetica, sans-serif
+font-size = 16pt
+font-weight = 
+font-style = 
+fill = white
+fill-opacity = 1
+text-anchor = middle
+filter = url(#dropshadow)
+
+[webgl_viewopts]
+voxlines = false
+voxline_color = #FFFFFF
+voxline_width = 0.01
+specularity = 1.0
+overlayscale = 1
+anim_speed = 2
+bumpy_flatmap = false
+
+[curvature]
+contrast = 0.25
+brightness = 0.5
+# Defines smoothing kernel for computation of vertex-wise curvature; None is default
+smooth = None
+# Use / don't use thresholded curvature for quickflat.
+threshold = True
+# Determines how smooth / thresholded pre-computed curvature is in webgl display; 0 is thresholded, 1 is totally smooth
+webgl_smooth = 0.0
+
+[webgl]
+layers = rois,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       dockerfile: Dockerfile.realtimefmri
     command: web_interface
     devices:
-      - "${EVENT_DEVICE}:${EVENT_DEVICE}"
+      - "${EVENT_DEVICE}:/dev/input/event3"
     ports:
       - "127.0.0.1:8050:8050"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,9 +7,15 @@ services:
       dockerfile: Dockerfile.realtimefmri
     command: web_interface
     devices:
-      - "/dev/input/event3:/dev/input/event3"
+      - "${EVENT_DEVICE}:${EVENT_DEVICE}"
     ports:
       - "127.0.0.1:8050:8050"
+    volumes:
+      - "${PYCORTEX_STORE}:/data/pycortex_store"
+      - "${PIPELINE_PATH}:/root/.local/share/realtimefmri/pipelines"
+      - "${TEST_DATASET_PATH}:/root/.local/share/realtimefmri/datasets/test_dataset"
+    restart: always
 
   redis:
     image: redis
+    restart: always

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -1,0 +1,32 @@
+Using ``docker-compose``
+============
+
+Installation
+------------
+
+Assuming you have docker installed, install ``docker-compose`` following the instructions `here https://docs.docker.com/compose/install/`.
+
+
+Configuration
+-------------
+Modify the ``.env`` file with the appropriate paths and device number. In particular, set the following variables to point to
+
+- ``PYCORTEX_STORE``: pycortex store with the subjects' surfaces and transforms
+- ``PIPELINE_PATH``: path where pipelines are stored
+- ``TEST_DATASET_PATH``: path where the test dataset is stored
+- ``EVENT_DEVICE``: keyboard input device
+
+Running ``docker-compose``
+--------------------------
+
+From the path containing the ``docker-compose.yaml`` file, run the following command:
+
+.. code-block:: bash
+   
+   docker-compose up -d
+
+It will pull the ``redis`` docker image, as well as build the ``realtimefmri`` image, and finally start both containers. To stop them, run
+
+.. code-block:: bash
+   
+   docker-compose down

--- a/docs/source/docker.rst
+++ b/docs/source/docker.rst
@@ -19,7 +19,7 @@ Modify the ``.env`` file with the appropriate paths and device number. In partic
 Running ``docker-compose``
 --------------------------
 
-From the path containing the ``docker-compose.yaml`` file, run the following command:
+From the path containing the ``docker-compose.yml`` file, run the following command:
 
 .. code-block:: bash
    


### PR DESCRIPTION
With this PR all paths can be specified in the `.env` file, reducing the amount of data that needs to be copied when building the docker image. Everything can just be mounted.

Also the containers are set to restart always, in case something funky happens.