### PR TITLE
ENH: samba share for getting new volumes from scanner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,22 @@ services:
       - "${PYCORTEX_STORE}:/data/pycortex_store"
       - "${PIPELINE_PATH}:/root/.local/share/realtimefmri/pipelines"
       - "${TEST_DATASET_PATH}:/root/.local/share/realtimefmri/datasets/test_dataset"
+      - scanner:/root/.local/share/realtimefmri/scanner
     restart: always
 
   redis:
     image: redis
     restart: always
+
+  samba:
+    build:
+      context: "./samba"
+      dockerfile: Dockerfile
+    ports:
+      - "0.0.0.0:139:139"
+      - "0.0.0.0:445:445"
+    volumes:
+      - scanner:/mnt/scanner
+
+volumes:
+  scanner:

--- a/samba/Dockerfile
+++ b/samba/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:18.04
+
+RUN apt update && apt install samba -y
+RUN mkdir -p /usr/local/samba/var/
+ADD smb.conf /etc/samba/smb.conf
+
+RUN mkdir /mnt/scanner
+
+WORKDIR /
+ADD run.sh run.sh
+RUN chmod u+x run.sh
+CMD ["/run.sh"]

--- a/samba/run.sh
+++ b/samba/run.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+SAMBA_USER=rtfmri
+SAMBA_PASSWORD=password
+adduser --disabled-password --gecos "" rtfmri
+echo -ne "$SAMBA_PASSWORD\n$SAMBA_PASSWORD\n" | smbpasswd -a -s $SAMBA_USER
+service smbd start
+tail -F /var/log/samba/log.smbd

--- a/samba/smb.conf
+++ b/samba/smb.conf
@@ -1,0 +1,234 @@
+# This is the main Samba configuration file. You should read the
+# smb.conf(5) manual page in order to understand the options listed
+# here. Samba has a huge number of configurable options (perhaps too
+# many!) most of which are not shown in this example
+#
+# For a step to step guide on installing, configuring and using samba, 
+# read the Samba-HOWTO-Collection. This may be obtained from:
+#  http://www.samba.org/samba/docs/Samba-HOWTO-Collection.pdf
+#
+# Many working examples of smb.conf files can be found in the 
+# Samba-Guide which is generated daily and can be downloaded from: 
+#  http://www.samba.org/samba/docs/Samba-Guide.pdf
+#
+# Any line which starts with a ; (semi-colon) or a # (hash) 
+# is a comment and is ignored. In this example we will use a #
+# for commentry and a ; for parts of the config file that you
+# may wish to enable
+#
+# NOTE: Whenever you modify this file you should run the command "testparm"
+# to check that you have not made any basic syntactic errors. 
+#
+#======================= Global Settings =====================================
+[global]
+
+# workgroup = NT-Domain-Name or Workgroup-Name, eg: MIDEARTH
+   workgroup = MYGROUP
+
+# server string is the equivalent of the NT Description field
+   server string = Samba Server
+
+# Server role. Defines in which mode Samba will operate. Possible
+# values are "standalone server", "member server", "classic primary
+# domain controller", "classic backup domain controller", "active
+# directory domain controller".
+#
+# Most people will want "standalone server" or "member server".
+# Running as "active directory domain controller" will require first
+# running "samba-tool domain provision" to wipe databases and create a
+# new domain.
+   server role = standalone server
+
+# This option is important for security. It allows you to restrict
+# connections to machines which are on your local network. The
+# following example restricts access to two C class networks and
+# the "loopback" interface. For more examples of the syntax see
+# the smb.conf man page
+;   hosts allow = 192.168.1. 192.168.2. 127.
+hosts allow 192.168.1. 192.168.2. 127. 172.17.
+
+# Uncomment this if you want a guest account, you must add this to /etc/passwd
+# otherwise the user "nobody" is used
+;  guest account = pcguest
+
+# this tells Samba to use a separate log file for each machine
+# that connects
+;   log file = /usr/local/samba/var/log.%m
+
+# Put a capping on the size of the log files (in Kb).
+   max log size = 50
+
+# Specifies the Kerberos or Active Directory realm the host is part of
+;   realm = MY_REALM
+
+# Backend to store user information in. New installations should 
+# use either tdbsam or ldapsam. smbpasswd is available for backwards 
+# compatibility. tdbsam requires no further configuration.
+;   passdb backend = tdbsam
+
+# Using the following line enables you to customise your configuration
+# on a per machine basis. The %m gets replaced with the netbios name
+# of the machine that is connecting.
+# Note: Consider carefully the location in the configuration file of
+#       this line.  The included file is read at that point.
+;   include = /usr/local/samba/lib/smb.conf.%m
+
+# Configure Samba to use multiple interfaces
+# If you have multiple network interfaces then you must list them
+# here. See the man page for details.
+;   interfaces = 192.168.12.2/24 192.168.13.2/24 
+
+bind interfaces only = no
+interfaces = lo 192.168.12.2/24 192.168.13.2/24 172.17.0.2/16
+
+# Where to store roving profiles (only for Win95 and WinNT)
+#        %L substitutes for this servers netbios name, %U is username
+#        You must uncomment the [Profiles] share below
+;   logon path = \\%L\Profiles\%U
+
+# Windows Internet Name Serving Support Section:
+# WINS Support - Tells the NMBD component of Samba to enable it's WINS Server
+;   wins support = yes
+
+# WINS Server - Tells the NMBD components of Samba to be a WINS Client
+#	Note: Samba can be either a WINS Server, or a WINS Client, but NOT both
+;   wins server = w.x.y.z
+
+# WINS Proxy - Tells Samba to answer name resolution queries on
+# behalf of a non WINS capable client, for this to work there must be
+# at least one	WINS Server on the network. The default is NO.
+;   wins proxy = yes
+
+# DNS Proxy - tells Samba whether or not to try to resolve NetBIOS names
+# via DNS nslookups. The default is NO.
+   dns proxy = no 
+
+# These scripts are used on a domain controller or stand-alone 
+# machine to add or delete corresponding unix accounts
+;  add user script = /usr/sbin/useradd %u
+;  add group script = /usr/sbin/groupadd %g
+;  add machine script = /usr/sbin/adduser -n -g machines -c Machine -d /dev/null -s /bin/false %u
+;  delete user script = /usr/sbin/userdel %u
+;  delete user from group script = /usr/sbin/deluser %u %g
+;  delete group script = /usr/sbin/groupdel %g
+
+
+#============================ Share Definitions ==============================
+[homes]
+   comment = Home Directories
+   browseable = no
+   writable = yes
+
+# Un-comment the following and create the netlogon directory for Domain Logons
+; [netlogon]
+;   comment = Network Logon Service
+;   path = /usr/local/samba/lib/netlogon
+;   guest ok = yes
+;   writable = no
+;   share modes = no
+
+
+# Un-comment the following to provide a specific roving profile share
+# the default is to use the user's home directory
+;[Profiles]
+;    path = /usr/local/samba/profiles
+;    browseable = no
+;    guest ok = yes
+
+
+# NOTE: If you have a BSD-style print system there is no need to 
+# specifically define each individual printer
+[printers]
+   comment = All Printers
+   path = /usr/spool/samba
+   browseable = no
+# Set public = yes to allow user 'guest account' to print
+   guest ok = no
+   writable = no
+   printable = yes
+
+# This one is useful for people to share files
+;[tmp]
+;   comment = Temporary file space
+;   path = /tmp
+;   read only = no
+;   public = yes
+
+# A publicly accessible directory, but read only, except for people in
+# the "staff" group
+;[public]
+;   comment = Public Stuff
+;   path = /home/samba
+;   public = yes
+;   writable = no
+;   printable = no
+;   write list = @staff
+
+# Other examples. 
+#
+# A private printer, usable only by fred. Spool data will be placed in fred's
+# home directory. Note that fred must have write access to the spool directory,
+# wherever it is.
+;[fredsprn]
+;   comment = Fred's Printer
+;   valid users = fred
+;   path = /homes/fred
+;   printer = freds_printer
+;   public = no
+;   writable = no
+;   printable = yes
+
+# A private directory, usable only by fred. Note that fred requires write
+# access to the directory.
+;[fredsdir]
+;   comment = Fred's Service
+;   path = /usr/somewhere/private
+;   valid users = fred
+;   public = no
+;   writable = yes
+;   printable = no
+
+# a service which has a different directory for each machine that connects
+# this allows you to tailor configurations to incoming machines. You could
+# also use the %U option to tailor it by user name.
+# The %m gets replaced with the machine name that is connecting.
+;[pchome]
+;  comment = PC Directories
+;  path = /usr/pc/%m
+;  public = no
+;  writable = yes
+
+# A publicly accessible directory, read/write to all users. Note that all files
+# created in the directory by users will be owned by the default user, so
+# any user with access can delete any other user's files. Obviously this
+# directory must be writable by the default user. Another user could of course
+# be specified, in which case all files would be owned by that user instead.
+;[public]
+;   path = /usr/somewhere/else/public
+;   public = yes
+;   only guest = yes
+;   writable = yes
+;   printable = no
+
+# The following two entries demonstrate how to share a directory so that two
+# users can place files there that will be owned by the specific users. In this
+# setup, the directory should be writable by both users and should have the
+# sticky bit set on it to prevent abuse. Obviously this could be extended to
+# as many users as required.
+;[myshare]
+;   comment = Mary's and Fred's stuff
+;   path = /usr/somewhere/shared
+;   valid users = mary fred
+;   public = no
+;   writable = yes
+;   printable = no
+;   create mask = 0765
+
+# Real-time fMRI directory
+[rtfmri]
+   comment = Real-time fMRI network directory
+   path = /mnt/scanner
+   valid users = rtfmri
+   public = no
+   writable = yes
+   printable = no


### PR DESCRIPTION
Addresses #9

Transfer of incoming volumes between the scanner console and real-time computer involves the SAMBA network file share protocol. A) The real-time computer "serves" directory ``/mnt/scanner``. B) the scanner console mounts the directory (using built-in Windows network drive tools). New files created on the scanner console show up in the real-time computer network-shared folder (using Siemens ``ideacmd``).

This PR attempts a containerized solution to this problem. It adds two new components:
- A ``samba`` container
- A ``scanner`` docker volume

Basic pipeline for how images go from scanner console to realtimefmri code. I use the ``hostname(container):directory`` syntax to make clear what I am referring to. The <--> indicate communication between devices:
- ``scanner:Z:\\`` <-samba share (``rtfmri``)-> ``stimmy(samba):/mnt/scanner`` <-docker volume (``scanner``)-> ``stimmy(realtimefmri):/root/.local/share/realtimefmri/scanner``.

I have tested this set up by making a third container that represents the scanner console:
```shell
docker run -it --privileged --network="realtimefmri_default" ubuntu:18.04 bash

>> apt update
>> apt install smbclient cifs-utils -y

>> useradd rtfmri  # make linux user
>> smbpasswd -a rtfmri  # make samba user, give dummy password ``password``
>> mkdir /mnt/scanner

>> mount -t cifs //172.18.0.4/rtfmri /mnt/scanner -o username=rtfmri,noexec
>> touch test_volume
```

This results in a file ``test_volume`` appearing on the ``realtimefmri`` container in the folder ``/root/.local/share/realtimefmri/scanner`.

TODO:
- I forgot that I could also test using a windows docker container, more like what we have in BIC
- Real life test in BIC