### PR TITLE
ENH: new working pycortex webgl viewer

### DIFF
--- a/Dockerfile.realtimefmri
+++ b/Dockerfile.realtimefmri
@@ -21,11 +21,13 @@ COPY data/pycortex-options.cfg /root/.config/pycortex/options.cfg
 
 # realtimefmri
 RUN mkdir -p /code/realtimefmri/realtimefmri
-COPY requirements.txt /code/realtimefmri
-COPY setup.py /code/realtimefmri
-COPY realtimefmri /code/realtimefmri/realtimefmri
 WORKDIR /code/realtimefmri
+
+COPY requirements.txt .
 RUN pip3 install -r requirements.txt
+
+COPY setup.py .
+COPY realtimefmri ./realtimefmri
 
 RUN pip3 install .
 # RUN pip3 install git+https://github.com/gallantlab/realtimefmri.git
@@ -34,4 +36,5 @@ RUN python3 -c "import realtimefmri"
 WORKDIR /
 ENV PATH="$HOME/abin:$PATH"
 EXPOSE 8050
+EXPOSE 8051
 ENTRYPOINT ["realtimefmri"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "${EVENT_DEVICE}:/dev/input/event3"
     ports:
       - "127.0.0.1:8050:8050"
+      - "127.0.0.1:8051:8051"
     volumes:
       - "${PYCORTEX_STORE}:/data/pycortex_store"
       - "${PIPELINE_PATH}:/root/.local/share/realtimefmri/pipelines"

--- a/realtimefmri/pipelines/preproc-viewer.yaml
+++ b/realtimefmri/pipelines/preproc-viewer.yaml
@@ -1,0 +1,43 @@
+global_parameters:
+  n_skip: 0
+
+pipeline:
+  - name: debug
+    step: realtimefmri.preprocess.Debug
+    input: [ raw_image_nii ]
+    output: [ nii_repr, nii_shape ]
+
+  - name: nifti_to_volume
+    step: realtimefmri.preprocess.NiftiToVolume
+    input: [ raw_image_nii ]
+    output: [ volume ]
+
+  - name: send_volume
+    step: realtimefmri.stimulate.SendToDashboard
+    kwargs: { name: volume, plot_type: mosaic }
+    input: [ volume ]
+
+  - name: gm_mask
+    step: realtimefmri.preprocess.ApplyMask
+    kwargs: { surface: RGfs, transform: 20170705RG_movies, mask_type: thick}
+    input: [ volume ]
+    output: [ gm_responses ]
+
+  - name: zscore
+    step: realtimefmri.preprocess.OnlineZScore
+
+  - name: array_mean
+    step: realtimefmri.preprocess.ArrayMean
+    kwargs: { dimensions: [0]}
+    input: [ gm_responses ]
+    output: [ gm_mean ]
+
+  - name: send_gm
+    step: realtimefmri.stimulate.SendToDashboard
+    kwargs: { name: gm_mean, plot_type: bar }
+    input: [ gm_mean ]
+
+  - name: flatmap
+    step: realtimefmri.stimulate.SendToPycortexViewer
+    kwargs: { name: flatmap }
+    input: [ gm_responses ]

--- a/realtimefmri/pipelines/preproc-viewer.yaml
+++ b/realtimefmri/pipelines/preproc-viewer.yaml
@@ -23,9 +23,6 @@ pipeline:
     input: [ volume ]
     output: [ gm_responses ]
 
-  - name: zscore
-    step: realtimefmri.preprocess.OnlineZScore
-
   - name: array_mean
     step: realtimefmri.preprocess.ArrayMean
     kwargs: { dimensions: [0]}

--- a/realtimefmri/preprocess.py
+++ b/realtimefmri/preprocess.py
@@ -97,7 +97,7 @@ class Pipeline(object):
         Run the data in ```data_dict``` through each of the preprocessing steps
     """
     def __init__(self, pipeline, global_parameters={}, static_pipeline={}, recording_id=None,
-                 log=False, output_socket=None, verbose=False):
+                 log=False, verbose=False):
         if recording_id is None:
             recording_id = 'recording_{}'.format(time.strftime('%Y%m%d_%H%M'))
 
@@ -107,7 +107,6 @@ class Pipeline(object):
 
         self.recording_id = recording_id
         self.log = log
-        self.output_socket = output_socket
 
         self.build(pipeline, static_pipeline, global_parameters)
 
@@ -366,9 +365,8 @@ class ApplyMask(PreprocessingStep):
         Parameters
         -----------
         volume : array
-            Array with dimensions consistent with pycortex
         """
-        return volume[self.mask.T]
+        return volume[self.mask]
 
 
 class ArrayMean(PreprocessingStep):

--- a/realtimefmri/viewer.py
+++ b/realtimefmri/viewer.py
@@ -17,8 +17,6 @@ class PyCortexViewer(object):
 
     def __init__(self, surface, transform, mask_type='thick', vmin=-1., vmax=1.,
                  **kwargs):
-        super(PyCortexViewer, self).__init__()
-
         npts = cortex.db.get_mask(surface, transform, mask_type).sum()
         data = np.zeros((self.bufferlen, npts), 'float32')
         vol = cortex.Volume(data, surface, transform, vmin=vmin, vmax=vmax)

--- a/realtimefmri/viewer.py
+++ b/realtimefmri/viewer.py
@@ -59,13 +59,10 @@ class PyCortexViewer(object):
         subscriber.subscribe('viewer')
         logger.info('Listening for volumes')
         for message in subscriber.listen():
-            logger.info('Received volume')
-            try:
+            if message['type'] == 'message':
+                logger.info('Received volume')
                 vol = pickle.loads(message['data'])
                 self.update_viewer(vol)
-
-            except Exception as e:
-                logger.warning(e)
 
 
 def serve(surface, transform, mask_type, vmin, vmax):

--- a/realtimefmri/viewer.py
+++ b/realtimefmri/viewer.py
@@ -1,0 +1,77 @@
+import time
+import pickle
+import cortex
+import numpy as np
+import redis
+from realtimefmri import config
+from realtimefmri.utils import get_logger
+
+
+logger = get_logger('viewer', to_console=True, to_network=True)
+
+r = redis.StrictRedis(config.REDIS_HOST)
+
+
+class PyCortexViewer(object):
+    bufferlen = 15
+
+    def __init__(self, surface, transform, mask_type='thick', vmin=-1., vmax=1.,
+                 **kwargs):
+        super(PyCortexViewer, self).__init__()
+
+        npts = cortex.db.get_mask(surface, transform, mask_type).sum()
+        data = np.zeros((self.bufferlen, npts), 'float32')
+        vol = cortex.Volume(data, surface, transform, vmin=vmin, vmax=vmax)
+        logger.info('starting pycortex viewer')
+        view = cortex.webgl.show(vol, open_browser=True, autoclose=False, port=8051)
+        logger.info(f'started pycortex viewer {surface}, {transform}, {npts}')
+
+        self.surface = surface
+        self.transform = transform
+        self.mask_type = mask_type
+
+        self.view = view
+        self.active = True
+        self.i = 0
+
+    def update_viewer(self, volume):
+        logger.info(f"Updating pycortex viewer")
+        volume = volume.astype('float32')
+        volume = cortex.Volume(volume, self.surface, self.transform)
+        mosaic, _ = cortex.mosaic(volume.volume[0], show=False)
+
+        i, = self.view.setFrame()
+        i = round(i)
+        new_frame = (i + 1) % self.bufferlen
+        self.view.dataviews.data.data[0]._setData(new_frame, mosaic)
+
+        i, = self.view.setFrame()
+        i = round(i)
+        self.view.playpause('play')
+        logger.info('start pause')
+        time.sleep(1)
+        logger.info('stop pause')
+        self.view.playpause('pause')
+        self.view.setFrame(i + 0.99)
+
+    def run(self):
+        subscriber = r.pubsub()
+        subscriber.subscribe('viewer')
+        logger.info('Listening for volumes')
+        for message in subscriber.listen():
+            logger.info('Received volume')
+            try:
+                vol = pickle.loads(message['data'])
+                self.update_viewer(vol)
+
+            except Exception as e:
+                logger.warning(e)
+
+
+def serve(surface, transform, mask_type, vmin, vmax):
+    viewer = PyCortexViewer(surface, transform, mask_type, vmin, vmax)
+    viewer.run()
+
+
+if __name__ == "__main__":
+    serve()

--- a/realtimefmri/web_interface/apps/control_panel.py
+++ b/realtimefmri/web_interface/apps/control_panel.py
@@ -110,7 +110,7 @@ def collect_ttl_status(n, session_id):
             process = start_task(collect_ttl.collect_ttl, 'redis')
             while not process.is_alive():
                 time.sleep(0.1)
-            logger.info(f"Started TTL collector (pid {pid})")
+            logger.info(f"Started TTL collector (pid {process.pid})")
             r.set(session_id + '_collect_ttl_pid', process.pid)
         else:
             logger.info(f"Stopping TTL collector (pid {pid})")
@@ -136,7 +136,7 @@ def collect_volumes_status(n, session_id):
             process = start_task(collect_volumes.collect_volumes)
             while not process.is_alive():
                 time.sleep(0.1)
-            logger.info(f"Started volume collector (pid {pid})")
+            logger.info(f"Started volume collector (pid {process.pid})")
             r.set(session_id + '_collect_volumes_pid', process.pid)
         else:
             logger.info(f"Stopping volume collector (pid {pid})")
@@ -162,7 +162,7 @@ def collect_status(n, session_id):
             process = start_task(collect.collect)
             while not process.is_alive():
                 time.sleep(0.1)
-            logger.info(f"Started collector viewer (pid {pid})")
+            logger.info(f"Started collector viewer (pid {process.pid})")
             r.set(session_id + '_collect_pid', process.pid)
         else:
             logger.info(f"Stopping collector viewer (pid {pid})")
@@ -190,7 +190,7 @@ def preprocess_status(n, recording_id, preproc_config, session_id):
             process = start_task(preprocess.preprocess, recording_id, preproc_config)
             while not process.is_alive():
                 time.sleep(0.1)
-            logger.info(f"Started preprocessor (pid {pid})")
+            logger.info(f"Started preprocessor (pid {process.pid})")
             r.set(session_id + '_preprocess_pid', process.pid)
         else:
             logger.info(f"Stopping preprocessor (pid {pid})")
@@ -218,7 +218,7 @@ def viewer_status(n, session_id, surface, transform):
             process = start_task(viewer.serve, surface, transform, "thick", 0, 2000)
             while not process.is_alive():
                 time.sleep(0.1)
-            logger.info(f"Started pycortex viewer (pid {pid})")
+            logger.info(f"Started pycortex viewer (pid {process.pid})")
             r.set(session_id + '_viewer_pid', process.pid)
         else:
             logger.info(f"Stopping pycortex viewer (pid {pid})")

--- a/realtimefmri/web_interface/apps/control_panel.py
+++ b/realtimefmri/web_interface/apps/control_panel.py
@@ -106,11 +106,11 @@ def collect_ttl_status(n, session_id):
     if n is not None:
         pid = r.get(session_id + '_collect_ttl_pid')
         if pid is None:
-            logger.info(f"Starting TTL collector (pid {pid})")
             label = 'o'
             process = start_task(collect_ttl.collect_ttl, 'redis')
             while not process.is_alive():
                 time.sleep(0.1)
+            logger.info(f"Started TTL collector (pid {pid})")
             r.set(session_id + '_collect_ttl_pid', process.pid)
         else:
             logger.info(f"Stopping TTL collector (pid {pid})")
@@ -132,12 +132,11 @@ def collect_volumes_status(n, session_id):
     if n is not None:
         pid = r.get(session_id + '_collect_volumes_pid')
         if pid is None:
-            logger.info(f"Starting volume collector (pid {pid})")
-
             label = 'o'
             process = start_task(collect_volumes.collect_volumes)
             while not process.is_alive():
                 time.sleep(0.1)
+            logger.info(f"Started volume collector (pid {pid})")
             r.set(session_id + '_collect_volumes_pid', process.pid)
         else:
             logger.info(f"Stopping volume collector (pid {pid})")
@@ -159,11 +158,11 @@ def collect_status(n, session_id):
     if n is not None:
         pid = r.get(session_id + '_collect_pid')
         if pid is None:
-            logger.info(f"Starting collector viewer (pid {pid})")
             label = 'o'
             process = start_task(collect.collect)
             while not process.is_alive():
                 time.sleep(0.1)
+            logger.info(f"Started collector viewer (pid {pid})")
             r.set(session_id + '_collect_pid', process.pid)
         else:
             logger.info(f"Stopping collector viewer (pid {pid})")
@@ -187,11 +186,11 @@ def preprocess_status(n, recording_id, preproc_config, session_id):
     if n is not None:
         pid = r.get(session_id + '_preprocess_pid')
         if pid is None:
-            logger.info(f"Starting preprocessor (pid {pid})")
             label = 'o'
             process = start_task(preprocess.preprocess, recording_id, preproc_config)
             while not process.is_alive():
                 time.sleep(0.1)
+            logger.info(f"Started preprocessor (pid {pid})")
             r.set(session_id + '_preprocess_pid', process.pid)
         else:
             logger.info(f"Stopping preprocessor (pid {pid})")
@@ -215,11 +214,11 @@ def viewer_status(n, session_id, surface, transform):
     if n is not None:
         pid = r.get(session_id + '_viewer_pid')
         if pid is None:
-            logger.info(f"Starting pycortex viewer (pid {pid})")
             label = 'o'
             process = start_task(viewer.serve, surface, transform, "thick", 0, 2000)
             while not process.is_alive():
                 time.sleep(0.1)
+            logger.info(f"Started pycortex viewer (pid {pid})")
             r.set(session_id + '_viewer_pid', process.pid)
         else:
             logger.info(f"Stopping pycortex viewer (pid {pid})")

--- a/realtimefmri/web_interface/apps/control_panel.py
+++ b/realtimefmri/web_interface/apps/control_panel.py
@@ -17,7 +17,12 @@ from realtimefmri import collect_ttl
 from realtimefmri import collect
 from realtimefmri import preprocess
 from realtimefmri import config
+from realtimefmri import viewer
 from realtimefmri.web_interface.app import app
+from realtimefmri.utils import get_logger
+
+
+logger = get_logger('control_panel', to_console=True, to_network=True)
 
 session_id = 'admin'
 layout = html.Div([html.Div(session_id, id='session-id'),  # , style={'display': 'none'}),
@@ -28,13 +33,13 @@ layout = html.Div([html.Div(session_id, id='session-id'),  # , style={'display':
                    # TTL status
                    html.Div([html.Button('x', id='collect-ttl-status',
                                          className='status-indicator'),
-                             html.Span('Collect TTL', className='collect-label'),
+                             html.Span('Collect TTL', className='status-label'),
                              html.Button('Simulate TTL', id='simulate-ttl')]),
 
                    # volumes status
                    html.Div([html.Button('x', id='collect-volumes-status',
                                          className='status-indicator'),
-                             html.Span('Collect volumes', className='collect-label'),
+                             html.Span('Collect volumes', className='status-label'),
                              html.Button('Simulate volume', id='simulate-volume'),
                              dcc.Dropdown(id='simulated-dataset', value='',
                                           options=[{'label': d, 'value': d}
@@ -43,16 +48,26 @@ layout = html.Div([html.Div(session_id, id='session-id'),  # , style={'display':
 
                    # collect status
                    html.Div([html.Button('x', id='collect-status', className='status-indicator'),
-                             html.Span('Collect', className='collect-label')]),
+                             html.Span('Collect', className='status-label')]),
 
                    # preprocess status
                    html.Div([html.Button('x', id='preprocess-status', 
                                          className='status-indicator'),
-                             html.Span('Preprocess', className='collect-label'),
+                             html.Span('Preprocess', className='status-label'),
                              dcc.Dropdown(id='preproc-config', value='',
                                           options=[{'label': p, 'value': p}
                                                    for p in config.get_pipelines('preproc')],
                                           style={'display': 'inline-block', 'width': '200px'})]),
+                   # pycortex viewer status
+                   html.Div([html.Button('x', id='viewer-status',
+                                         className='status-indicator'),
+                             html.Span('Viewer', className='status-label'),
+                             dcc.Input(id='pycortex-surface',
+                                       placeholder='...enter pycortex surface name...',
+                                       type='text', value='RGfs'),
+                             dcc.Input(id='pycortex-transform',
+                                       placeholder='...enter pycortex transform name...',
+                                       type='text', value='20170705RG_movies')]),
 
                    html.Div(id='empty-div1', children=[]),
                    html.Div(id='empty-div2', children=[]),
@@ -74,7 +89,6 @@ class TaskProxy(threading.Thread):
         p = multiprocessing.Process(target=self.target, args=self.args)
         self.target_process = p
         p.start()
-        print(p.pid)
         p.join()
 
 
@@ -92,12 +106,14 @@ def collect_ttl_status(n, session_id):
     if n is not None:
         pid = r.get(session_id + '_collect_ttl_pid')
         if pid is None:
+            logger.info(f"Starting TTL collector (pid {pid})")
             label = 'o'
             process = start_task(collect_ttl.collect_ttl, 'redis')
             while not process.is_alive():
                 time.sleep(0.1)
             r.set(session_id + '_collect_ttl_pid', process.pid)
         else:
+            logger.info(f"Stopping TTL collector (pid {pid})")
             label = 'x'
             pid = int(pid)
             os.kill(pid, signal.SIGKILL)
@@ -116,12 +132,15 @@ def collect_volumes_status(n, session_id):
     if n is not None:
         pid = r.get(session_id + '_collect_volumes_pid')
         if pid is None:
+            logger.info(f"Starting volume collector (pid {pid})")
+
             label = 'o'
             process = start_task(collect_volumes.collect_volumes)
             while not process.is_alive():
                 time.sleep(0.1)
             r.set(session_id + '_collect_volumes_pid', process.pid)
         else:
+            logger.info(f"Stopping volume collector (pid {pid})")
             label = 'x'
             pid = int(pid)
             os.kill(pid, signal.SIGKILL)
@@ -140,12 +159,14 @@ def collect_status(n, session_id):
     if n is not None:
         pid = r.get(session_id + '_collect_pid')
         if pid is None:
+            logger.info(f"Starting collector viewer (pid {pid})")
             label = 'o'
             process = start_task(collect.collect)
             while not process.is_alive():
                 time.sleep(0.1)
             r.set(session_id + '_collect_pid', process.pid)
         else:
+            logger.info(f"Stopping collector viewer (pid {pid})")
             label = 'x'
             pid = int(pid)
             os.kill(pid, signal.SIGKILL)
@@ -166,12 +187,14 @@ def preprocess_status(n, recording_id, preproc_config, session_id):
     if n is not None:
         pid = r.get(session_id + '_preprocess_pid')
         if pid is None:
+            logger.info(f"Starting preprocessor (pid {pid})")
             label = 'o'
             process = start_task(preprocess.preprocess, recording_id, preproc_config)
             while not process.is_alive():
                 time.sleep(0.1)
             r.set(session_id + '_preprocess_pid', process.pid)
         else:
+            logger.info(f"Stopping preprocessor (pid {pid})")
             label = 'x'
             pid = int(pid)
             os.kill(pid, signal.SIGKILL)
@@ -183,12 +206,39 @@ def preprocess_status(n, recording_id, preproc_config, session_id):
         raise PreventUpdate()
 
 
+@app.callback(Output('viewer-status', 'children'),
+              [Input('viewer-status', 'n_clicks')],
+              [State('session-id', 'children'),
+               State('pycortex-surface', 'value'),
+               State('pycortex-transform', 'value')])
+def viewer_status(n, session_id, surface, transform):
+    if n is not None:
+        pid = r.get(session_id + '_viewer_pid')
+        if pid is None:
+            logger.info(f"Starting pycortex viewer (pid {pid})")
+            label = 'o'
+            process = start_task(viewer.serve, surface, transform, "thick", 0, 2000)
+            while not process.is_alive():
+                time.sleep(0.1)
+            r.set(session_id + '_viewer_pid', process.pid)
+        else:
+            logger.info(f"Stopping pycortex viewer (pid {pid})")
+            label = 'x'
+            pid = int(pid)
+            os.kill(pid, signal.SIGKILL)
+            r.delete(session_id + '_viewer_pid')
+
+        return label
+
+    else:
+        raise PreventUpdate()
+
+
 @app.callback(Output('empty-div4', 'children'),
               [Input('simulate-ttl', 'n_clicks')])
 def simulate_ttl(n):
     if n is not None:
-        print('simulating ttl at {}'.format(time.time()))
-        logging.info('simulating ttl')
+        logging.info('simulating ttl at {}'.format(time.time()))
         r.publish('ttl', 'message')
     else:
         raise PreventUpdate()
@@ -206,7 +256,7 @@ def simulate_volume(n, simulated_dataset, session_id):
             count = int(r.get(session_id + '_simulated_volume_count') or 0)
             count = count % len(paths)
 
-            print('Simulating volume {}'.format(count))
+            logger.info('Simulating volume {}'.format(count))
             path = paths[count]
             shutil.copy(path, op.join(config.SCANNER_DIR, str(uuid4()) + '.dcm'))
             count += 1

--- a/realtimefmri/web_interface/apps/dashboard.py
+++ b/realtimefmri/web_interface/apps/dashboard.py
@@ -12,7 +12,7 @@ from realtimefmri.web_interface.app import app
 from realtimefmri.utils import get_logger
 
 
-log = get_logger('dashboard', to_console=True, to_network=False)
+logger = get_logger('dashboard', to_console=True, to_network=False)
 
 
 def remove_prefix(text, prefix):
@@ -67,34 +67,36 @@ def update_data_list(n):
               [Input('interval-component', 'n_intervals'),
                Input('data-list', 'value')])
 def update_selected_graphs(n, selected_values):
-    if len(selected_values) == 0:
-        return go.Scatter()
-
     fig_specs = []
     traces = []
     for i, value in enumerate(selected_values):
-        data = pickle.loads(r.get(value))
-        plot_type = r.get(value + ':type')
-        if plot_type == b'scatter':
-            traces.append(go.Scatter(y=data))
-            fig_specs.append([{'colspan': 3}, None, None])
+        val = r.get(value)
+        if val is not None:
+            data = pickle.loads(val)
+            plot_type = r.get(value + ':type')
+            if plot_type == b'scatter':
+                traces.append(go.Scatter(y=data))
+                fig_specs.append([{'colspan': 3}, None, None])
 
-        elif plot_type == b'bar':
-            if isinstance(data, numbers.Number):
-                data = [data]
-            traces.append(go.Bar(y=data))
-            fig_specs.append([{'colspan': 3}, None, None])
+            elif plot_type == b'bar':
+                if isinstance(data, numbers.Number):
+                    data = [data]
+                traces.append(go.Bar(y=data))
+                fig_specs.append([{'colspan': 3}, None, None])
 
-        elif plot_type == b'timeseries':
-            traces.append(go.Scatter(y=[1, 2, 3]))
-            fig_specs.append([{'colspan': 3}, None, None])
+            elif plot_type == b'timeseries':
+                traces.append(go.Scatter(y=[1, 2, 3]))
+                fig_specs.append([{'colspan': 3}, None, None])
 
-        elif plot_type == b'mosaic':
-            traces.append(make_mosaic(data))
-            fig_specs.append([{}, {}, {}])
+            elif plot_type == b'mosaic':
+                traces.append(make_mosaic(data))
+                fig_specs.append([{}, {}, {}])
 
-        else:
-            warnings.warn('{} plot not implemented. Omitting this plot.'.format(plot_type))
+            else:
+                warnings.warn('{} plot not implemented. Omitting this plot.'.format(plot_type))
+
+    if len(traces) == 0:
+        return go.Scatter()
 
     fig = plotly.tools.make_subplots(rows=len(selected_values), cols=3, specs=fig_specs,
                                      print_grid=False)

--- a/realtimefmri/web_interface/assets/style.css
+++ b/realtimefmri/web_interface/assets/style.css
@@ -12,7 +12,7 @@ button {
 
 }
 
-.collect-label {
+.status-label {
   display: inline-block;
   width: 150px;
   margin: 0.2em;


### PR DESCRIPTION
Addresses #13 
Add a pycortex viewer. + a few other small changes are included here that are only loosely related to the issue -- sorry for the git messiness.

### Implementation
- A new stimulation class called ``SendToPycortexViewer`` that writes a volume to the redis database. Currently only one pycortex dataset can be shown at a time -- this could be extended to handle multiple datasets.
- A new module ``viewer.py`` that includes code to launch a pycortex viewer and make real-time updates to the data.
- The control panel now includes a button that will launch the pycortex viewer in a separate process.

### How to use it:
- Run the containers using ``docker-compose up --build``
- Visit localhost:8050/control-panel to bring up the control panel
- Select the ``preproc-viewer`` preprocessing pipeline
- Launch all of the processes (click the ``x``s)
- After launching the "Viewer", visit localhost:8051 to bring up the pycortex webgl viewer. Wait for the brain to appear.
- Click "Simulate TTL" then "Simulate volume"
- You should see the data in the pycortex viewer change