### PR TITLE
Siemens slice reversal

### DIFF
--- a/realtimefmri/collect.py
+++ b/realtimefmri/collect.py
@@ -1,10 +1,6 @@
 #!/usr/bin/env python3
-import os
 import os.path as op
 import struct
-import tempfile
-import subprocess
-import nibabel
 import pickle
 import redis
 from realtimefmri.utils import get_logger
@@ -13,7 +9,7 @@ from realtimefmri import image_utils
 
 
 def collect(verbose=True):
-    """Continuously monitor for incoming volumes, merge with TTL timestamps, and send to 
+    """Continuously monitor for incoming volumes, merge with TTL timestamps, and send to
     preprocessor
     """
     logger = get_logger('collector', to_console=verbose, to_network=True)
@@ -32,6 +28,8 @@ def collect(verbose=True):
             logger.info('Collected at {}'.format(timestamp))
 
             nii = image_utils.dicom_to_nifti(new_volume_path)
+            timestamped_volume = {'time': timestamp,
+                                  'volume': nii.get_data()}
 
             logger.debug('%s %s', op.basename(new_volume_path), str(nii.shape))
             redis_client.publish('timestamped_volume', pickle.dumps([image_number, timestamp, nii]))

--- a/realtimefmri/image_utils.py
+++ b/realtimefmri/image_utils.py
@@ -35,6 +35,22 @@ def dicom_to_nifti(dicom_path):
     return nii
 
 
+def secondary_mask(mask1, mask2, order='C'):
+    """
+    Given an array, X and two 3d masks, mask1 and mask2
+    X[mask1] = x
+    X[mask1 & mask2] = y
+    x[new_mask] = y
+    """
+    assert mask1.shape == mask2.shape
+    mask1_flat = mask1.ravel(order=order)
+    mask2_flat = mask2.ravel(order=order)
+
+    masks = np.c_[mask1_flat, mask2_flat]
+    masks = masks[mask1_flat, :]
+    return masks[:, 1].astype(bool)
+
+
 def register(volume, reference, output_transform=False, twopass=False):
     """Register the input image to the reference image
 

--- a/realtimefmri/online_moments.py
+++ b/realtimefmri/online_moments.py
@@ -42,9 +42,9 @@ class OnlineMoments(PreprocessingStep):
     def __init__(self, order=4, **kwargs):
         self.n = 0.0
         self.order = order
-        self.all_raw_moments = [0.0]*self.order
+        self.all_raw_moments = [0.0] * self.order
         for odx in range(self.order):
-            self.__setattr__('rawmnt%i'%(odx+1), self.all_raw_moments[odx])
+            self.__setattr__('rawmnt%i' % (odx + 1), self.all_raw_moments[odx])
 
     def __repr__(self):
         return '%s.online_moments' % (__name__)

--- a/realtimefmri/preprocess.py
+++ b/realtimefmri/preprocess.py
@@ -21,7 +21,7 @@ from realtimefmri import buffered_array
 logger = get_logger('preprocess', to_console=True, to_network=True)
 
 
-def preprocess(recording_id, pipeline_name, surface, transform, verbose=False, log=True, **kwargs):
+def preprocess(recording_id, pipeline_name, surface, transform, **kwargs):
     """Highest-level class for running preprocessing
 
     This class loads the preprocessing pipeline from the configuration
@@ -59,10 +59,10 @@ def preprocess(recording_id, pipeline_name, surface, transform, verbose=False, l
         if message['type'] == 'message':
             data = message['data']
             if data != 1:  # subscription message
-                image_number, timestamp, nii = pickle.loads(data)
-                logger.info(f'Received image {image_number}')
-                data_dict = {'image_number': image_number,
-                             'raw_image_nii': nii}
+                timestamped_volume = pickle.loads(data)
+                logger.info('Received image %d', timestamped_volume['image_number'])
+                data_dict = {'image_number': timestamped_volume['image_number'],
+                             'raw_image_nii': timestamped_volume['volume']}
                 data_dict = pipeline.process(data_dict)
 
 

--- a/realtimefmri/preprocess.py
+++ b/realtimefmri/preprocess.py
@@ -12,10 +12,13 @@ import numpy as np
 import redis
 import nibabel as nib
 import cortex
-from realtimefmri.image_utils import register
+from realtimefmri import image_utils
 from realtimefmri.utils import get_logger, load_class
 from realtimefmri import config
 from realtimefmri import buffered_array
+
+
+logger = get_logger('preprocess', to_console=True, to_network=True)
 
 
 def preprocess(recording_id, pipeline_name, surface, transform, verbose=False, log=True, **kwargs):
@@ -37,7 +40,6 @@ def preprocess(recording_id, pipeline_name, surface, transform, verbose=False, l
     verbose : bool
         Whether to log to the console
     """
-    log = get_logger('preprocess', to_console=verbose, to_network=log)
     redis_client = redis.StrictRedis(config.REDIS_HOST)
 
     config_path = op.join(config.PIPELINE_DIR, pipeline_name + '.yaml')
@@ -47,7 +49,7 @@ def preprocess(recording_id, pipeline_name, surface, transform, verbose=False, l
     pipeline_config['global_parameters']['surface'] = surface
     pipeline_config['global_parameters']['transform'] = transform
 
-    pipeline = Pipeline(log=log, verbose=verbose, **pipeline_config)
+    pipeline = Pipeline(**pipeline_config)
 
     n_skip = pipeline.global_parameters.get('n_skip', 0)
 
@@ -58,7 +60,7 @@ def preprocess(recording_id, pipeline_name, surface, transform, verbose=False, l
             data = message['data']
             if data != 1:  # subscription message
                 image_number, timestamp, nii = pickle.loads(data)
-                log.info('received image %d', image_number)
+                logger.info(f'Received image {image_number}')
                 data_dict = {'image_number': image_number,
                              'raw_image_nii': nii}
                 data_dict = pipeline.process(data_dict)
@@ -106,18 +108,11 @@ class Pipeline(object):
     process(data_dict)
         Run the data in ```data_dict``` through each of the preprocessing steps
     """
-    def __init__(self, pipeline, global_parameters={}, static_pipeline={}, recording_id=None,
-                 log=False, verbose=False):
+    def __init__(self, pipeline, global_parameters={}, static_pipeline={}, recording_id=None):
         if recording_id is None:
             recording_id = 'recording_{}'.format(time.strftime('%Y%m%d_%H%M'))
 
-        log = get_logger('preprocess.pipeline',
-                         to_console=verbose,
-                         to_network=log)
-
         self.recording_id = recording_id
-        self.log = log
-
         self.build(pipeline, static_pipeline, global_parameters)
 
     def build(self, pipeline, static_pipeline, global_parameters):
@@ -132,7 +127,7 @@ class Pipeline(object):
         """
         self.static_pipeline = []
         for step in static_pipeline:
-            self.log.debug('initializing %s' % step['name'])
+            logger.debug('Initializing %s' % step['name'])
             args = step.get('args', ())
             kwargs = step.get('kwargs', {})
             for k, v in global_parameters.items():
@@ -144,7 +139,7 @@ class Pipeline(object):
 
         self.pipeline = []
         for step in pipeline:
-            self.log.debug('initializing %s' % step['name'])
+            logger.debug('initializing %s' % step['name'])
             args = step.get('args', ())
             kwargs = step.get('kwargs', dict())
             for k, v in global_parameters.items():
@@ -201,10 +196,10 @@ class Pipeline(object):
         for step in self.pipeline:
             args = [data_dict[k] for k in step['input']]
 
-            self.log.info('running %s' % step['name'])
+            logger.info('running %s' % step['name'])
             outp = step['instance'].run(*args)
 
-            self.log.debug('finished %s' % step['name'])
+            logger.debug('finished %s' % step['name'])
 
             if not isinstance(outp, (list, tuple)):
                 outp = [outp]
@@ -338,7 +333,7 @@ class MotionCorrect(PreprocessingStep):
             print(self.reference_affine)
             warnings.warn('Input and reference volumes have different affines.')
 
-        return register(input_volume, self.reference_path, twopass=self.twopass)
+        return image_utils.register(input_volume, self.reference_path, twopass=self.twopass)
 
 
 class NiftiToVolume(PreprocessingStep):
@@ -347,6 +342,14 @@ class NiftiToVolume(PreprocessingStep):
     """
     def run(self, nii):
         return nii.get_data().T
+
+
+class VolumeToMosaic(PreprocessingStep):
+    def __init__(self, dim=0, **kwargs):
+        self.dim = dim
+
+    def run(self, volume):
+        return cortex.mosaic(volume, dim=self.dim, show=False)[0]
 
 
 class ApplyMask(PreprocessingStep):
@@ -404,23 +407,7 @@ class ArrayMean(PreprocessingStep):
             return np.mean(array, axis=self.dimensions)
 
 
-def secondary_mask(mask1, mask2, order='C'):
-    """
-    Given an array, X and two 3d masks, mask1 and mask2
-    X[mask1] = x
-    X[mask1 & mask2] = y
-    x[new_mask] = y
-    """
-    assert mask1.shape == mask2.shape
-    mask1_flat = mask1.ravel(order=order)
-    mask2_flat = mask2.ravel(order=order)
-
-    masks = np.c_[mask1_flat, mask2_flat]
-    masks = masks[mask1_flat, :]
-    return masks[:, 1].astype(bool)
-
-
-class ApplyMask2(PreprocessingStep):
+class ApplySecondaryMask(PreprocessingStep):
     """Apply a second mask to a vector produced by a first mask.
 
     Given a vector of voxel activity from a primary mask, return voxel activity
@@ -455,7 +442,7 @@ class ApplyMask2(PreprocessingStep):
     def __init__(self, surface, transform, mask_type_1, mask_type_2, **kwargs):
         mask1 = cortex.db.get_mask(surface, transform, mask_type_1).T  # in xyz
         mask2 = cortex.db.get_mask(surface, transform, mask_type_2).T  # in xyz
-        self.mask = secondary_mask(mask1, mask2, order='F')
+        self.mask = image_utils.secondary_mask(mask1, mask2, order='F')
 
     def run(self, x):
         if x.ndim > 1:
@@ -580,18 +567,15 @@ class WMDetrend(PreprocessingStep):
         return gm_activity - gm_trend
 
 
-class RunningZScore(PreprocessingStep):
-    def __init__(self, **kwargs):
-        """Preprocessing module that z-scores data using running mean and variance
-        """
-        self.n = 0
-
-    def run(self, inp):
+class IncrementalMeanStd(PreprocessingStep):
+    """Preprocessing module that z-scores data using running mean and variance
+    """
+    def run(self, array):
         """Run the z-scoring on one time point and update the prior
 
         Parameters
         ----------
-        inp : numpy.ndarray
+        array : numpy.ndarray
             A vector of data to be z-scored
 
         Returns
@@ -599,16 +583,17 @@ class RunningZScore(PreprocessingStep):
         The input array z-scored using the posterior mean and variance
         """
         if not hasattr(self, 'data'):
-            self.data = buffered_array.BufferedArray(inp.size, dtype=inp.dtype)
-            self.data.append(inp)
-            return np.zeros(inp.size, dtype=inp.dtype)
+            self.array_shape = array.shape
+            self.data = buffered_array.BufferedArray(array.size, dtype=array.dtype)
+            self.data.append(array.ravel())
+            return None, None
 
-        self.data.append(inp)
+        self.data.append(array.ravel())
 
         std = np.std(self.data.get_array(), 0)
         mean = np.mean(self.data.get_array(), 0)
 
-        return (inp - mean) / std
+        return mean.reshape(self.array_shape), std.reshape(self.array_shape)
 
     def reset(self):
         del self.data
@@ -665,49 +650,19 @@ class RunningMeanStd(PreprocessingStep):
         return self.mean, self.std
 
 
-class VoxelZScore(PreprocessingStep):
-    """Compute a z-score of a vector
-
-    Z-score a vector given precomputed mean and standard deviation
-
-    Attributes
-    ----------
-    mean : numpy.ndarray
-        A vector of voxel means
-    std : numpy.ndarray
-        A vector of voxel standard deviations
+class ZScore(PreprocessingStep):
+    """Compute a z-scored version of an input array given precomputed means and standard deviations
 
     Methods
     -------
-    zscore(data)
-        Apply the mean and standard deviation to compute and return a z-scored
-        version of the data
-    run(inp, mean=None, std=None)
+    run(inp, mean, std)
         Return the z-scored version of the data
     """
-    def __init__(self, **kwargs):
-        self.mean = None
-        self.std = None
-
-    def zscore(self, data):
-        return (data - self.mean) / self.std
-
-    def run(self, inp, mean=None, std=None):
-        # update mean and std if provided
-        if mean is not None:
-            self.mean = mean
-        if std is not None:
-            self.std = std
-
-        # zscore
-        if self.mean is None:
-            z = inp
+    def run(self, array, mean, std):
+        if mean is None:
+            return np.zeros_like(array)
         else:
-            if (self.std == 0).all():
-                z = np.zeros_like(inp)
-            else:
-                z = self.zscore(inp)
-        return z
+            return (array - mean) / std
 
 
 if __name__ == '__main__':

--- a/realtimefmri/preprocess.py
+++ b/realtimefmri/preprocess.py
@@ -233,9 +233,6 @@ def load_reference(surface, transform):
 
 
 class Debug(object):
-    def __init__(self, **kwargs):
-        pass
-
     def run(self, nii):
         return str(nii), nii.shape
 

--- a/realtimefmri/preprocess.py
+++ b/realtimefmri/preprocess.py
@@ -232,7 +232,7 @@ def load_reference(surface, transform):
         return nib.load(ref_path)
 
 
-class Debug(object):
+class Debug(PreprocessingStep):
     def run(self, nii):
         return str(nii), nii.shape
 

--- a/realtimefmri/web_interface/assets/addSlider.js
+++ b/realtimefmri/web_interface/assets/addSlider.js
@@ -1,0 +1,15 @@
+
+var sliderDiv = document.createElement("div");
+sliderDiv.id = "slider-div";
+var slider = document.createElement("input");
+slider.type = "range";
+slider.id = "graph-height-slider";
+slider.style.width = "90vw";
+slider.min = 400; slider.max = 1600; slider.value = 400;
+sliderDiv.append(slider);
+document.body.prepend(sliderDiv);
+
+slider.oninput = function () {
+	var c = document.getElementById("graph-div");
+	c.style.height = this.value + "px";
+}

--- a/realtimefmri/web_interface/assets/style.css
+++ b/realtimefmri/web_interface/assets/style.css
@@ -17,3 +17,20 @@ button {
   width: 150px;
   margin: 0.2em;
 }
+
+#container {
+  display: inline-block;
+  width: 90vw;
+  min-width: 400px;
+  height: 90vh;
+  min-height: 400px},
+
+}
+
+#graph-div {
+  height: 100%;
+}
+#graphs {
+  display: inline-block;
+  height: 100%
+}


### PR DESCRIPTION
Long story short: pycortex does dicom to nifti conversion using ``mri_convert``, and we are using ``dcm2niix``. This is great because we don't need to install all of freesurfer to convert dicoms to nifti images. This is not great because ``mri_convert`` and ``dcm2niix`` interpret the affine info slightly differently. ``mri_convert`` flips the second image dimension relative to ``dcm2niix``. I'm not really sure why, but I am sure that it breaks motion corrections using AFNI's ``3dvolreg``. So I'm taking the easy way out and hand-altering the volume and affine to match the dimension ordering that ``mri_convert`` (and pycortex) uses.
