### PR TITLE
[WIP] NF: add base code for experiments in jsPsych

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "realtimefmri/experiments/static/jsPsych"]
+	path = realtimefmri/experiments/static/jsPsych
+	url = git@github.com:jspsych/jsPsych.git

--- a/realtimefmri/experiments/base-experiment.html
+++ b/realtimefmri/experiments/base-experiment.html
@@ -1,0 +1,67 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>My experiment</title>
+        <script src="static/jsPsych/jspsych.js"></script>
+        <script src="static/jsPsych/plugins/jspsych-html-keyboard-response.js"></script>
+        <script src="static/jsPsych/plugins/jspsych-image-keyboard-response.js"></script>
+        <script src="static/jsPsych/plugins/jspsych-animation.js"></script>
+        <link href="static/jsPsych/css/jspsych.css" rel="stylesheet" type="text/css"></link>
+    </head>
+    <body></body>
+    <script>
+
+    /* XXX: perhaps we need to randomly sample stimulus and trial duration
+       to avoid trigger locking of each stimulus? */
+    var STIMULUS_DURATION = 2000;
+    var TRIAL_DURATION = 3000;
+    // create timeline variable
+    var timeline = [];
+    var previous_trial_onset = 0;
+
+    // "trigger" trial -- waiting for 5 to start the experiment
+    var wait_trigger = {
+        type: 'html-keyboard-response',
+        stimulus: 'Waiting for trigger...',
+        choices: ['5'],
+        on_finish: function(data) {
+          previous_trial_onset = data.time_elapsed;
+        }
+    }
+    timeline.push(wait_trigger);
+
+    var ok = {
+        type: 'html-keyboard-response',
+        stimulus: 'OK'
+    }
+    // timeline.push(ok);
+
+    // let's make a function that creates a new trial variable
+    function make_trial(img_fn) {
+      var trial = {
+        type: 'image-keyboard-response',
+        stimulus: img_fn,
+        choices: ['5'],
+        stimulus_duration: STIMULUS_DURATION,
+        trial_duration: TRIAL_DURATION,
+        response_ends_trial: false,
+        on_finish: function(data) {
+          data.duration = data.time_elapsed - previous_trial_onset;
+          previous_trial_onset = data.time_elapsed;
+        }
+      }
+      return trial;
+    }
+
+    timeline.push(make_trial("static/test.jpeg"));
+    timeline.push(make_trial("static/test.jpeg"));
+
+    jsPsych.init({
+        timeline: timeline,
+        on_finish: function() {
+          jsPsych.data.displayData();
+        }
+    })
+
+    </script>
+</html>


### PR DESCRIPTION
Things to discuss and figure out

- [ ] should we randomly sample stimulus/trial duration to avoid TR locking
- [ ] how to store data (right now the sample experiment just displays the result data on the screen)
- [ ] make figures for experiment (my task)

Also for reference, this is an example of what is stored

```json
[
	{
		"rt": 2580,
		"stimulus": "Waiting for trigger...",
		"key_press": 53,
		"trial_type": "html-keyboard-response",
		"trial_index": 0,
		"time_elapsed": 2584,
		"internal_node_id": "0.0-0.0"
	},
	{
		"rt": null,
		"stimulus": "static/test.jpeg",
		"key_press": null,
		"trial_type": "image-keyboard-response",
		"trial_index": 1,
		"time_elapsed": 5589,
		"internal_node_id": "0.0-1.0",
		"duration": 3005
	},
	{
		"rt": null,
		"stimulus": "static/test.jpeg",
		"key_press": null,
		"trial_type": "image-keyboard-response",
		"trial_index": 2,
		"time_elapsed": 8592,
		"internal_node_id": "0.0-2.0",
		"duration": 3003
	}
]
```

The first trial just waits for the trigger (a `'5'`). I added a `duration` variable to make sure that the duration is what we want (with some error). The stimulus onset can be recovered using the `time_elapsed` variable.